### PR TITLE
Filter unit tests on "Unit" regex and output test coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ test: test-unit
 
 .PHONY: test-unit
 test-unit: test-deps
-	go test ./...
+	go test ./... -run 'Unit' -coverprofile=coverage.out
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Filter tests by checking the regex "Unit" against the test name to prevent integration tests running and output the test coverage for use with Sonar.