### PR TITLE
Add Staging Environment

### DIFF
--- a/terraform/groups/lambda/main.tf
+++ b/terraform/groups/lambda/main.tf
@@ -4,6 +4,7 @@ provider "aws" {
 
 terraform {
   backend "s3" {
+    encrypt = true
   }
 }
 

--- a/terraform/groups/lambda/main.tf
+++ b/terraform/groups/lambda/main.tf
@@ -40,6 +40,7 @@ module "lambda" {
   release_version      = var.release_version
   release_bucket_name  = var.release_bucket_name
   execution_role       = module.lambda-roles.execution_role
+  open_lambda_environment_variables = var.open_lambda_environment_variables
   aws_profile          = var.aws_profile
   subnet_ids           = local.test_and_development_subnet_ids
   security_group_ids   = [module.security-group.lambda_into_vpc_id]

--- a/terraform/groups/lambda/module-lambda/main.tf
+++ b/terraform/groups/lambda/module-lambda/main.tf
@@ -22,10 +22,8 @@ resource "aws_lambda_function" "payment_reconciler" {
   environment {
     variables = merge (
       data.vault_generic_secret.lambda_environment_variables.data,
-      {
-        "SFTP_PORT"=22,
-        "LOGLEVEL"="trace"
-      }
+      var.open_lambda_environment_variables,
+      { "SFTP_PORT"=22 }
     )
   }
 }

--- a/terraform/groups/lambda/module-lambda/variables.tf
+++ b/terraform/groups/lambda/module-lambda/variables.tf
@@ -19,6 +19,9 @@ variable service {
 variable release_version {
   type        = string
 }
+variable open_lambda_environment_variables {
+  type        = map(string)
+}
 variable execution_role {
   type        = string
   description = "IAM role from lambda-roles module used for executing the Lambda."

--- a/terraform/groups/lambda/profiles/development-eu-west-2/aard1/vars
+++ b/terraform/groups/lambda/profiles/development-eu-west-2/aard1/vars
@@ -9,3 +9,4 @@ aws_region = "eu-west-2"
 release_bucket_name = "development-eu-west-2.release.ch.gov.uk"
 remote_state_bucket = "ch-development-terraform-state-london"
 remote_state_key = "env:/development/development/development.tfstate"
+open_lambda_environment_variables = {LOGLEVEL="trace"}

--- a/terraform/groups/lambda/profiles/development-eu-west-2/apollo1/vars
+++ b/terraform/groups/lambda/profiles/development-eu-west-2/apollo1/vars
@@ -9,3 +9,4 @@ aws_region = "eu-west-2"
 release_bucket_name = "development-eu-west-2.release.ch.gov.uk"
 remote_state_bucket = "ch-development-terraform-state-london"
 remote_state_key = "env:/development/development/development.tfstate"
+open_lambda_environment_variables = {LOGLEVEL="trace"}

--- a/terraform/groups/lambda/profiles/development-eu-west-2/cidev/vars
+++ b/terraform/groups/lambda/profiles/development-eu-west-2/cidev/vars
@@ -9,3 +9,4 @@ aws_region = "eu-west-2"
 release_bucket_name = "development-eu-west-2.release.ch.gov.uk"
 remote_state_bucket = "ch-development-terraform-state-london"
 remote_state_key = "env:/development/development/development.tfstate"
+open_lambda_environment_variables = {LOGLEVEL="trace"}

--- a/terraform/groups/lambda/profiles/development-eu-west-2/tcats1/vars
+++ b/terraform/groups/lambda/profiles/development-eu-west-2/tcats1/vars
@@ -9,3 +9,4 @@ aws_region = "eu-west-2"
 release_bucket_name = "development-eu-west-2.release.ch.gov.uk"
 remote_state_bucket = "ch-development-terraform-state-london"
 remote_state_key = "env:/development/development/development.tfstate"
+open_lambda_environment_variables = {LOGLEVEL="trace"}

--- a/terraform/groups/lambda/profiles/staging-eu-west-2/staging/vars
+++ b/terraform/groups/lambda/profiles/staging-eu-west-2/staging/vars
@@ -1,0 +1,11 @@
+# ------------------------------------------------------------------------------
+# Environment
+# ------------------------------------------------------------------------------
+
+environment = "staging"
+aws_profile = "staging-eu-west-2"
+cron_schedule = "cron(0/5 * * * ? *)"
+aws_region = "eu-west-2"
+release_bucket_name = "ch-service-staging-release.ch.gov.uk"
+remote_state_bucket = "ch-service-staging-terraform-state"
+remote_state_key = "env:/staging/staging/staging.tfstate"

--- a/terraform/groups/lambda/variables.tf
+++ b/terraform/groups/lambda/variables.tf
@@ -59,6 +59,12 @@ variable "cron_schedule" {
   description = "CloudWatch cron schedule expression for calling the Lambda function."
 }
 
+variable open_lambda_environment_variables {
+  type        = map(string)
+  description = "Lambda environment variables that do not require encryption."
+  default     = {}
+}
+
 # Vault
 variable "vault_username" {
   type        = string


### PR DESCRIPTION
Includes the following changes:
- Adds an environment profile for Staging
- Adds support for non-secret variables per environment.
- Since LOGLEVEL="trace" is no longer a hard-coded constant, added to all existing dev environments (as a non-secret variable).
- Adds encryption to the Terraform provider.

Resolves: DVOP-1274