### PR TITLE
Filter on refunded_at

### DIFF
--- a/dao/mongo.go
+++ b/dao/mongo.go
@@ -135,7 +135,7 @@ func (m *Mongo) GetRefundsData(reconciliationMetaData *models.ReconciliationMeta
 
 	collection := getMongoClient(m.Config.MongoDBURL).Database(m.Config.Database).Collection(m.Config.RefundsCollection)
 
-	cur, err := collection.Find(context.Background(), bson.M{"transaction_date": bson.M{
+	cur, err := collection.Find(context.Background(), bson.M{"refunded_at": bson.M{
 		"$gt": reconciliationMetaData.StartTime,
 		"$lt": reconciliationMetaData.EndTime,
 	}})


### PR DESCRIPTION
`transaction_date` could be more than 24 hours in the past, so filter on `refunded_at` to get the correct entries into the daily csv file